### PR TITLE
Bump v5.2.1

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/blog",
   "description": "my blogs",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "github.com/9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"

--- a/apps/slides/package.json
+++ b/apps/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/slides",
   "description": "my slides",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "dependencies": {
     "@types/impress": "0.5.29",
     "impress.js": "1.0.0"

--- a/lerna.json
+++ b/lerna.json
@@ -17,5 +17,5 @@
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "5.2.0"
+  "version": "5.2.1"
 }

--- a/packages/eslint-config-flowtype/package.json
+++ b/packages/eslint-config-flowtype/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@9renpoto/eslint-config-flowtype",
   "description": "flowtype with eslint",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "github.com/9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"
   },
   "dependencies": {
-    "@9renpoto/eslint-config": "^5.2.0",
+    "@9renpoto/eslint-config": "^5.2.1",
     "babel-eslint": "10.0.3",
     "eslint-plugin-flowtype": "4.3.0"
   },

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/eslint-config-react",
   "description": "my react eslint-config",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@9renpoto/eslint-config-typescript",
   "description": "TypeScript with eslint",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "github.com/9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"
   },
   "dependencies": {
-    "@9renpoto/eslint-config": "^5.2.0",
+    "@9renpoto/eslint-config": "^5.2.1",
     "@typescript-eslint/parser": "2.3.3"
   },
   "homepage": "https://github.com/9renpoto/frontend",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/eslint-config",
   "description": "my eslint config",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "github.com/9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/style",
   "description": "simple components",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "@9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/stylelint-config",
   "description": "@9renpoto stylelint config",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "@9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/stylelint-config/pulls"

--- a/packages/textlint-config-ja/package.json
+++ b/packages/textlint-config-ja/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/textlint-config-ja",
   "description": "Configrations for Japanese text linter",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "9renpoto",
   "dependencies": {
     "textlint-filter-rule-comments": "1.2.2",

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/tslint-config",
   "description": "@9nrepoto Linter Settings",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "@9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/tslint-config/issues"

--- a/sandbox/nest/package.json
+++ b/sandbox/nest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/nest",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "dependencies": {
     "@nestjs/common": "6.8.3",
     "@nestjs/core": "6.8.3",


### PR DESCRIPTION
## v5.2.1 (2019-10-12)

#### :rocket: Type: Feature
* `eslint-config-react`, `eslint-config`
  * [#1136](https://github.com/9renpoto/frontend/pull/1136) Update dependency eslint-config-prettier to v6.4.0 ([@renovate[bot]](https://github.com/apps/renovate))

#### :bug: Type: Bug
* `eslint-config-typescript`
  * [#1082](https://github.com/9renpoto/frontend/pull/1082) Update dependency @typescript-eslint/parser to v2.3.1 ([@renovate[bot]](https://github.com/apps/renovate))

#### Committers: 1
- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))