### PR TITLE
Bump v5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+## v5.4.0 (2019-11-30)
+
+#### :rocket: Type: Feature
+
+- `stylelint-config`
+  - [#1312](https://github.com/9renpoto/frontend/pull/1312) fix(deps): update dependency stylelint-config-prettier to v7 ([@renovate[bot]](https://github.com/apps/renovate))
+- `eslint-config-typescript`
+  - [#1302](https://github.com/9renpoto/frontend/pull/1302) fix(deps): update dependency @typescript-eslint/parser to v2.9.0 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#1285](https://github.com/9renpoto/frontend/pull/1285) fix(deps): update dependency @typescript-eslint/parser to v2.8.0 ([@renovate[bot]](https://github.com/apps/renovate))
+- `eslint-config-flowtype`
+  - [#1300](https://github.com/9renpoto/frontend/pull/1300) fix(deps): update dependency eslint-plugin-flowtype to v4.5.2 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#1262](https://github.com/9renpoto/frontend/pull/1262) fix(deps): update dependency eslint-plugin-flowtype to v4.4.1 ([@renovate[bot]](https://github.com/apps/renovate))
+- `eslint-config-react`, `eslint-config`
+  - [#1286](https://github.com/9renpoto/frontend/pull/1286) fix(deps): update dependency eslint-config-prettier to v6.7.0 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#1280](https://github.com/9renpoto/frontend/pull/1280) fix(deps): update dependency eslint-config-prettier to v6.6.0 ([@renovate[bot]](https://github.com/apps/renovate))
+- `tslint-config`
+  - [#1234](https://github.com/9renpoto/frontend/pull/1234) Update dependency tslint-config-standard to v9 ([@renovate[bot]](https://github.com/apps/renovate))
+
+#### Committers: 1
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+
+## v5.3.0 (2019-10-31)
+
+#### :rocket: Type: Feature
+
+- `eslint-config-react`, `stylelint-config`
+  - [#1225](https://github.com/9renpoto/frontend/pull/1225) feat: update linters ([@9renpoto](https://github.com/9renpoto))
+- Other
+  - [#1217](https://github.com/9renpoto/frontend/pull/1217) feat: generate apollo client ([@9renpoto](https://github.com/9renpoto))
+- `eslint-config-typescript`
+  - [#1214](https://github.com/9renpoto/frontend/pull/1214) Update dependency @typescript-eslint/parser to v2.6.0 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#1187](https://github.com/9renpoto/frontend/pull/1187) Update dependency @typescript-eslint/parser to v2.5.0 ([@renovate[bot]](https://github.com/apps/renovate))
+- `eslint-config-react`, `eslint-config`
+  - [#1206](https://github.com/9renpoto/frontend/pull/1206) Update dependency eslint-config-prettier to v6.5.0 ([@renovate[bot]](https://github.com/apps/renovate))
+
+#### Committers: 1
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+
+## v5.2.1 (2019-10-12)
+
+#### :rocket: Type: Feature
+
+- `eslint-config-react`, `eslint-config`
+  - [#1136](https://github.com/9renpoto/frontend/pull/1136) Update dependency eslint-config-prettier to v6.4.0 ([@renovate[bot]](https://github.com/apps/renovate))
+
+#### :bug: Type: Bug
+
+- `eslint-config-typescript`
+  - [#1082](https://github.com/9renpoto/frontend/pull/1082) Update dependency @typescript-eslint/parser to v2.3.1 ([@renovate[bot]](https://github.com/apps/renovate))
+
+#### Committers: 1
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/blog",
   "description": "my blogs",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": "github.com/9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"

--- a/apps/slides/package.json
+++ b/apps/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/slides",
   "description": "my slides",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "devDependencies": {
     "@types/vnu-jar": "17.11.0",
     "lite-server": "2.5.4",

--- a/lerna.json
+++ b/lerna.json
@@ -30,5 +30,5 @@
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "5.3.0"
+  "version": "5.4.0"
 }

--- a/packages/eslint-config-flowtype/package.json
+++ b/packages/eslint-config-flowtype/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@9renpoto/eslint-config-flowtype",
   "description": "flowtype with eslint",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": "github.com/9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"
   },
   "dependencies": {
-    "@9renpoto/eslint-config": "^5.3.0",
+    "@9renpoto/eslint-config": "^5.4.0",
     "babel-eslint": "10.0.3",
     "eslint-plugin-flowtype": "4.5.2"
   },

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/eslint-config-react",
   "description": "my react eslint-config",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": "9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@9renpoto/eslint-config-typescript",
   "description": "TypeScript with eslint",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": "github.com/9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"
   },
   "dependencies": {
-    "@9renpoto/eslint-config": "^5.3.0",
+    "@9renpoto/eslint-config": "^5.4.0",
     "@typescript-eslint/parser": "2.9.0"
   },
   "homepage": "https://github.com/9renpoto/frontend",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/eslint-config",
   "description": "my eslint config",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": "github.com/9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/style",
   "description": "thinking web",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": "@9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/frontend/issues"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/stylelint-config",
   "description": "@9renpoto stylelint config",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": "@9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/stylelint-config/pulls"

--- a/packages/textlint-config-ja/package.json
+++ b/packages/textlint-config-ja/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/textlint-config-ja",
   "description": "Configrations for Japanese text linter",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": "9renpoto",
   "dependencies": {
     "textlint-filter-rule-comments": "1.2.2",

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9renpoto/tslint-config",
   "description": "@9nrepoto Linter Settings",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "author": "@9renpoto",
   "bugs": {
     "url": "https://github.com/9renpoto/tslint-config/issues"

--- a/sandbox/nest/package.json
+++ b/sandbox/nest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/nest",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "dependencies": {
     "@nestjs/common": "6.10.2",
     "@nestjs/core": "6.10.2",


### PR DESCRIPTION
## v5.4.0 (2019-11-30)                     
                                                                                              
#### :rocket: Type: Feature                                                                   
* `stylelint-config`                           
  * [#1312](https://github.com/9renpoto/frontend/pull/1312) fix(deps): update dependency stylelint-config-prettier to v7 ([@renovate[bot]](https://github.com/apps/renovate))                
* `eslint-config-typescript`                                                                                                                                                                 
  * [#1302](https://github.com/9renpoto/frontend/pull/1302) fix(deps): update dependency @typescript-eslint/parser to v2.9.0 ([@renovate[bot]](https://github.com/apps/renovate))            
  * [#1285](https://github.com/9renpoto/frontend/pull/1285) fix(deps): update dependency @typescript-eslint/parser to v2.8.0 ([@renovate[bot]](https://github.com/apps/renovate))            
* `eslint-config-flowtype`                                                                    
  * [#1300](https://github.com/9renpoto/frontend/pull/1300) fix(deps): update dependency eslint-plugin-flowtype to v4.5.2 ([@renovate[bot]](https://github.com/apps/renovate))               
  * [#1262](https://github.com/9renpoto/frontend/pull/1262) fix(deps): update dependency eslint-plugin-flowtype to v4.4.1 ([@renovate[bot]](https://github.com/apps/renovate))               
* `eslint-config-react`, `eslint-config`                                                      
  * [#1286](https://github.com/9renpoto/frontend/pull/1286) fix(deps): update dependency eslint-config-prettier to v6.7.0 ([@renovate[bot]](https://github.com/apps/renovate))               
  * [#1280](https://github.com/9renpoto/frontend/pull/1280) fix(deps): update dependency eslint-config-prettier to v6.6.0 ([@renovate[bot]](https://github.com/apps/renovate))               
* `tslint-config`                              
  * [#1234](https://github.com/9renpoto/frontend/pull/1234) Update dependency tslint-config-standard to v9 ([@renovate[bot]](https://github.com/apps/renovate))                              

#### Committers: 1                             
- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))    