### PR TITLE
Action Required: Fix Renovate Configuration

### DIFF
--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -1,13 +1,12 @@
 {
   "name": "@9renpoto/renovate-config",
-  "version": "1.0.0",
+  "version": "5.4.0",
   "devDependencies": {
     "renovate": "19.71.5"
   },
   "keywords": [
     "renovate"
   ],
-  "private": true,
   "license": "MIT",
   "renovate-config": {
     "default": {


### PR DESCRIPTION
There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.

Error type: Cannot find preset's package (@9renpoto)
