### PR TITLE
chore: Bump v5.5.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,0 @@
-{
-  "extends": [
-    "@9renpoto/eslint-config-react",
-    "@9renpoto/eslint-config-typescript"
-  ],
-  "plugins": [
-    "jest"
-  ]
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
+.firebase
 .changelog
 
-gibo 2.2.3 by Simon Whitaker <sw@netcetera.org>
-https://github.com/simonwhitaker/gibo
-### https://raw.github.com/github/gitignore/21e9f06539cdbc1ccbbb2ce59cd667be3e172fc8/Node.gitignore
+### https://raw.github.com/github/gitignore/6c87d249af5f2b3f8ab65ae0a2648682ee4e8a2d/Node.gitignore
 
 # Logs
 logs
@@ -90,7 +89,7 @@ dist
 
 # Gatsby files
 .cache/
-# Comment in the public line in if your project uses Gatsby and *not* Next.js
+# Comment in the public line in if your project uses Gatsby and not Next.js
 # https://nextjs.org/blog/next-9-1#public-directory-support
 # public
 
@@ -108,3 +107,8 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test
+
+

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "@9renpoto/stylelint-config"
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v5.5.0 (2020-01-12)
+
+#### :rocket: Type: Feature
+
+- [#1362](https://github.com/9renpoto/frontend/pull/1362) feat(apps): Added 2019-end entry ([@9renpoto](https://github.com/9renpoto))
+- [#1329](https://github.com/9renpoto/frontend/pull/1329) chore: Added domains ([@9renpoto](https://github.com/9renpoto))
+
+#### :bug: Type: Bug
+
+- `eslint-config-flowtype`, `eslint-config-react`, `eslint-config-typescript`, `eslint-config`, `textlint-config-ja`
+  - [#1386](https://github.com/9renpoto/frontend/pull/1386) fix: deps ([@9renpoto](https://github.com/9renpoto))
+
+#### Committers: 2
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+- [@imgbot[bot]](https://github.com/apps/imgbot)
+
 ## v5.4.0 (2019-11-30)
 
 #### :rocket: Type: Feature

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ This repository is managed as monorepo.
 ## Tests
 
     yarn test
-     
-<figure><embed src="https://wakatime.com/share/@9renpoto/dc33f655-fbbb-4375-8182-d7059f550ef0.svg"></embed></figure>
 
 ## Contribute
 

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/blog",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "private": true,
   "description": "my blogs",
   "license": "https://github.com/9renpoto/frontend/blob/master/LICENSE",

--- a/apps/slides/package.json
+++ b/apps/slides/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/slides",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "private": true,
   "description": "my slides",
   "license": "https://github.com/9renpoto/frontend/blob/master/LICENSE",

--- a/lerna.json
+++ b/lerna.json
@@ -1,22 +1,11 @@
 {
-  "packages": [
-    "packages/*",
-    "examples/*",
-    "apps/*"
-  ],
+  "packages": ["packages/*", "examples/*", "apps/*"],
   "command": {
     "version": {
-      "allowBranch": [
-        "master",
-        "release"
-      ]
+      "allowBranch": ["master"]
     }
   },
-  "ignoreChanges": [
-    "**/__fixtures__/**",
-    "**/__tests__/**",
-    "**/*.md"
-  ],
+  "ignoreChanges": ["**/__fixtures__/**", "**/__tests__/**", "**/*.md"],
   "changelog": {
     "labels": {
       "enhancement": ":rocket: Enhancement",
@@ -30,5 +19,5 @@
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "5.4.0"
+  "version": "5.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,15 @@
     "ts-loader": "6.2.1",
     "ts-node": "8.6.1"
   },
+  "eslintConfig": {
+    "extends": [
+      "@9renpoto/eslint-config-react",
+      "@9renpoto/eslint-config-typescript"
+    ],
+    "plugins": [
+      "jest"
+    ]
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"
@@ -85,6 +94,9 @@
     "plugins": [
       "remark-preset-lint-recommended"
     ]
+  },
+  "stylelint": {
+    "extends": "@9renpoto/stylelint-config"
   },
   "workspaces": [
     "packages/*",

--- a/packages/eslint-config-flowtype/package.json
+++ b/packages/eslint-config-flowtype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/eslint-config-flowtype",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
@@ -24,7 +24,7 @@
     "flowtype"
   ],
   "dependencies": {
-    "@9renpoto/eslint-config": "^5.4.0",
+    "@9renpoto/eslint-config": "^5.5.0",
     "babel-eslint": "^10.0.3",
     "eslint-plugin-flowtype": "^4.5.3"
   },

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@9renpoto/eslint-config-react",
-  "version": "5.4.0",
+  "version": "5.5.0",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "description": "my react eslint-config",
   "license": "MIT",
   "repository": {

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/eslint-config-typescript",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
@@ -24,7 +24,7 @@
     "TypeScript"
   ],
   "dependencies": {
-    "@9renpoto/eslint-config": "^5.4.0",
+    "@9renpoto/eslint-config": "^5.5.0",
     "@typescript-eslint/parser": "^2.15.0"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/eslint-config",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/style",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/stylelint-config",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },

--- a/packages/textlint-config-ja/package.json
+++ b/packages/textlint-config-ja/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/textlint-config-ja",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/tslint-config",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },


### PR DESCRIPTION
## v5.5.0 (2020-01-12)

#### :rocket: Type: Feature

- [#1362](https://github.com/9renpoto/frontend/pull/1362) feat(apps): Added 2019-end entry ([@9renpoto](https://github.com/9renpoto))
- [#1329](https://github.com/9renpoto/frontend/pull/1329) chore: Added domains ([@9renpoto](https://github.com/9renpoto))

#### :bug: Type: Bug

- `eslint-config-flowtype`, `eslint-config-react`, `eslint-config-typescript`, `eslint-config`, `textlint-config-ja`
  - [#1386](https://github.com/9renpoto/frontend/pull/1386) fix: deps ([@9renpoto](https://github.com/9renpoto))

#### Committers: 2

- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
- [@imgbot[bot]](https://github.com/apps/imgbot)