### PR TITLE
Release v7.3.0 (2021-03-07)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,18 +11,3 @@ updates:
     - 9renpoto
   labels:
     - 'Type: Maintenance'
-- package-ecosystem: 'npm'
-  directory: '/'
-  schedule:
-    interval: daily
-    time: '03:00'
-    timezone: 'Asia/Tokyo'
-  open-pull-requests-limit: 99
-  assignees:
-    - 9renpoto
-  labels:
-    - 'Type: Maintenance'
-  commit-message:
-    prefix: fix
-    prefix-development: chore
-    include: scope

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:js-lib"],
+  "extends": ["config:base"],
   "assignees": ["9renpoto"],
   "labels": ["Type: Maintenance"],
   "packageRules": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,70 @@
+## v7.3.0 (2021-03-07)
+
+#### :rocket: Type: Feature
+
+- [#2379](https://github.com/9renpoto/frontend/pull/2379) chore: status-box ([@9renpoto](https://github.com/9renpoto))
+
+#### :bug: Type: Bug
+
+- [#2444](https://github.com/9renpoto/frontend/pull/2444) fix: typo ([@9renpoto](https://github.com/9renpoto))
+
+#### :house: Maintenance
+
+- `eslint-config-flowtype`, `eslint-config-nuxt`, `eslint-config-react`, `eslint-config-typescript`, `eslint-config-vue`, `eslint-config`
+  - [#2758](https://github.com/9renpoto/frontend/pull/2758) chore: update dependencies ([@9renpoto](https://github.com/9renpoto))
+- `eslint-config-typescript`, `tsconfig`
+  - [#2754](https://github.com/9renpoto/frontend/pull/2754) Revert "chore(deps): update dependency typescript to v4.2.3" ([@9renpoto](https://github.com/9renpoto))
+  - [#2751](https://github.com/9renpoto/frontend/pull/2751) chore(deps): update dependency typescript to v4.2.3 ([@renovate[bot]](https://github.com/apps/renovate))
+- Other
+  - [#2742](https://github.com/9renpoto/frontend/pull/2742) fix(deps): bump pug-code-gen from 2.0.2 to 2.0.3 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2744](https://github.com/9renpoto/frontend/pull/2744) fix(deps): bump linaria from 2.0.2 to 2.1.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2740](https://github.com/9renpoto/frontend/pull/2740) fix(deps): bump @nuxt/content from 1.13.1 to 1.14.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2722](https://github.com/9renpoto/frontend/pull/2722) fix(deps): bump @typescript-eslint/parser from 4.16.0 to 4.16.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2741](https://github.com/9renpoto/frontend/pull/2741) chore(deps): update dependency lerna to v4 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#2694](https://github.com/9renpoto/frontend/pull/2694) chore(deps-dev): bump @nuxt/typescript-build from 1.0.3 to 2.0.6 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2695](https://github.com/9renpoto/frontend/pull/2695) fix(deps): bump eslint-plugin-flowtype from 5.3.0 to 5.3.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2713](https://github.com/9renpoto/frontend/pull/2713) fix(deps): bump @typescript-eslint/parser from 4.15.2 to 4.16.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2714](https://github.com/9renpoto/frontend/pull/2714) fix(deps): bump core-js from 3.9.0 to 3.9.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2687](https://github.com/9renpoto/frontend/pull/2687) fix(deps): bump eslint-plugin-flowtype from 5.2.0 to 5.3.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2688](https://github.com/9renpoto/frontend/pull/2688) fix(deps): bump core-js from 3.8.3 to 3.9.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2689](https://github.com/9renpoto/frontend/pull/2689) fix(deps): bump @typescript-eslint/parser from 4.15.1 to 4.15.2 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2682](https://github.com/9renpoto/frontend/pull/2682) fix(deps): update dependency react-instantsearch-dom to v6.10.0 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#2681](https://github.com/9renpoto/frontend/pull/2681) chore(deps): update dependency @nuxt/types to v2.15.2 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#2659](https://github.com/9renpoto/frontend/pull/2659) fix(deps): bump @headlessui/react from 0.3.0 to 0.3.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2663](https://github.com/9renpoto/frontend/pull/2663) fix(deps): bump @typescript-eslint/parser from 4.15.0 to 4.15.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2656](https://github.com/9renpoto/frontend/pull/2656) Next ([@9renpoto](https://github.com/9renpoto))
+  - [#2640](https://github.com/9renpoto/frontend/pull/2640) fix(deps): bump @nuxtjs/axios from 5.13.0 to 5.13.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2646](https://github.com/9renpoto/frontend/pull/2646) fix(deps): bump @nuxt/content from 1.12.0 to 1.13.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2648](https://github.com/9renpoto/frontend/pull/2648) chore(deps-dev): bump typescript from 3.9.7 to 3.9.9 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2637](https://github.com/9renpoto/frontend/pull/2637) fix(deps): bump @typescript-eslint/parser from 4.14.2 to 4.15.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2629](https://github.com/9renpoto/frontend/pull/2629) chore(deps): update dependency vnu-jar to v21 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#2626](https://github.com/9renpoto/frontend/pull/2626) chore(deps-dev): bump @vue/test-utils from 1.1.2 to 1.1.3 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2627](https://github.com/9renpoto/frontend/pull/2627) chore(deps): update dependency ts-loader to v8.0.15 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#2617](https://github.com/9renpoto/frontend/pull/2617) fix(deps): bump gatsby-plugin-google-gtag from 2.7.0 to 2.8.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2621](https://github.com/9renpoto/frontend/pull/2621) fix(deps): bump @typescript-eslint/parser from 4.14.1 to 4.14.2 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2611](https://github.com/9renpoto/frontend/pull/2611) chore(deps): update dependency cypress to v6.4.0 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#2610](https://github.com/9renpoto/frontend/pull/2610) fix(deps): bump @nuxtjs/axios from 5.12.5 to 5.13.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2608](https://github.com/9renpoto/frontend/pull/2608) fix(deps): bump @nuxt/content from 1.11.1 to 1.12.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2609](https://github.com/9renpoto/frontend/pull/2609) chore(deps-dev): bump @prettier/plugin-pug from 1.13.2 to 1.13.3 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2596](https://github.com/9renpoto/frontend/pull/2596) fix(deps): bump @typescript-eslint/parser from 4.14.0 to 4.14.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2597](https://github.com/9renpoto/frontend/pull/2597) fix(deps): bump graphql from 15.4.0 to 15.5.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2600](https://github.com/9renpoto/frontend/pull/2600) fix(deps): bump @nuxtjs/pwa from 3.3.4 to 3.3.5 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2583](https://github.com/9renpoto/frontend/pull/2583) fix(deps): bump gatsby-plugin-google-gtag from 2.6.0 to 2.7.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+  - [#2581](https://github.com/9renpoto/frontend/pull/2581) Update dependabot.yml ([@9renpoto](https://github.com/9renpoto))
+- `eslint-config-typescript`
+  - [#2700](https://github.com/9renpoto/frontend/pull/2700) chore(deps-dev): bump typescript from 3.9.9 to 4.2.2 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
+- `eslint-config-nuxt`, `eslint-config`
+  - [#2655](https://github.com/9renpoto/frontend/pull/2655) chore(deps): update dependency eslint to v7.20.0 ([@renovate[bot]](https://github.com/apps/renovate))
+- `textlint-config-ja`
+  - [#2590](https://github.com/9renpoto/frontend/pull/2590) chore(deps): update dependency textlint to v11.8.1 ([@renovate[bot]](https://github.com/apps/renovate))
+  - [#2589](https://github.com/9renpoto/frontend/pull/2589) chore(deps): update dependency textlint to v11.8.0 ([@renovate[bot]](https://github.com/apps/renovate))
+- `eslint-config-react`
+  - [#2580](https://github.com/9renpoto/frontend/pull/2580) fix: deps ([@9renpoto](https://github.com/9renpoto))
+
+#### Committers: 1
+
+- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))
+
 ## v7.2.0 (2020-11-12)
 
 #### :rocket: Type: Feature

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/blog",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "private": true,
   "description": "my blogs",
   "license": "https://github.com/9renpoto/frontend/blob/master/LICENSE",
@@ -23,7 +23,7 @@
     "gatsby"
   ],
   "dependencies": {
-    "@9renpoto/ui": "^7.3.0",
+    "@9renpoto/ui": "^7.4.0",
     "gatsby": "2.32.9",
     "gatsby-image": "2.11.0",
     "gatsby-plugin-algolia": "0.16.3",
@@ -51,6 +51,8 @@
     "preact": "10.5.12",
     "preact-render-to-string": "^5.1.10",
     "prismjs": "1.23.0",
+    "react": "npm:@preact/compat@^0.0.4",
+    "react-dom": "npm:@preact/compat@^0.0.4",
     "react-helmet": "6.1.0",
     "react-instantsearch-dom": "6.10.3",
     "react-typography": "0.16.19",
@@ -59,8 +61,6 @@
     "typescript-styled-plugin": "0.15.0",
     "typography": "0.16.19",
     "typography-theme-github": "0.16.19",
-    "react": "npm:@preact/compat@^0.0.4",
-    "react-dom": "npm:@preact/compat@^0.0.4",
     "vfile-message": "^2.0.2"
   },
   "devDependencies": {

--- a/apps/slides/package.json
+++ b/apps/slides/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/slides",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "private": true,
   "description": "my slides",
   "license": "https://github.com/9renpoto/frontend/blob/master/LICENSE",

--- a/lerna.json
+++ b/lerna.json
@@ -13,11 +13,12 @@
       "Type: Documentation ": ":memo: Documentation",
       "Type: Feature": ":rocket: Type: Feature",
       "Type: Bug": ":bug: Type: Bug",
-      "Type: Breaking Change": ":boom: Type: Breaking Change"
+      "Type: Breaking Change": ":boom: Type: Breaking Change",
+      "Type: Maintenance": ":house: Maintenance"
     },
     "cacheDir": ".changelog"
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "7.3.0"
+  "version": "7.4.0"
 }

--- a/packages/eslint-config-flowtype/package.json
+++ b/packages/eslint-config-flowtype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/eslint-config-flowtype",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "flowtype with eslint",
   "license": "MIT",
   "repository": {
@@ -18,7 +18,7 @@
     "flowtype"
   ],
   "dependencies": {
-    "@9renpoto/eslint-config": "^7.3.0",
+    "@9renpoto/eslint-config": "^7.4.0",
     "babel-eslint": "^10.0.3",
     "eslint-plugin-flowtype": "^5.2.0"
   },

--- a/packages/eslint-config-nuxt/package.json
+++ b/packages/eslint-config-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/eslint-config-nuxt",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "private": true,
   "license": "MIT",
   "main": "index.js",

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/eslint-config-react",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "my react eslint-config",
   "license": "MIT",
   "repository": {

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/eslint-config-typescript",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "TypeScript with eslint",
   "license": "MIT",
   "repository": {
@@ -18,7 +18,7 @@
     "TypeScript"
   ],
   "dependencies": {
-    "@9renpoto/eslint-config": "^7.3.0",
+    "@9renpoto/eslint-config": "^7.4.0",
     "@typescript-eslint/parser": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/eslint-config-vue",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "private": true,
   "license": "MIT",
   "main": "index.js"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/eslint-config",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "my eslint config",
   "license": "MIT",
   "repository": {

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/style",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "thinking web",
   "license": "MIT",
   "repository": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/stylelint-config",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "@9renpoto stylelint config",
   "license": "MIT",
   "repository": {

--- a/packages/textlint-config-ja/package.json
+++ b/packages/textlint-config-ja/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/textlint-config-ja",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "Configrations for Japanese text linter",
   "license": "MIT",
   "author": "9renpoto",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/tsconfig",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "Shared TypeScript config for my projects",
   "license": "MIT",
   "main": "tsconfig.json",

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/tslint-config",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "private": true,
   "description": "@9nrepoto Linter Settings",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/ui",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/sandbox/nuxt/package.json
+++ b/sandbox/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/nuxt",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "private": true,
   "scripts": {
     "build": "nuxt-ts build",

--- a/sandbox/vuepress/package.json
+++ b/sandbox/vuepress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@9renpoto/vuepress",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "private": true,
   "scripts": {
     "build": "vuepress build docs",


### PR DESCRIPTION
## v7.3.0 (2021-03-07)

#### :rocket: Type: Feature

- [#2379](https://github.com/9renpoto/frontend/pull/2379) chore: status-box ([@9renpoto](https://github.com/9renpoto))

#### :bug: Type: Bug

- [#2444](https://github.com/9renpoto/frontend/pull/2444) fix: typo ([@9renpoto](https://github.com/9renpoto))

#### :house: Maintenance

- `eslint-config-flowtype`, `eslint-config-nuxt`, `eslint-config-react`, `eslint-config-typescript`, `eslint-config-vue`, `eslint-config`
  - [#2758](https://github.com/9renpoto/frontend/pull/2758) chore: update dependencies ([@9renpoto](https://github.com/9renpoto))
- `eslint-config-typescript`, `tsconfig`
  - [#2754](https://github.com/9renpoto/frontend/pull/2754) Revert "chore(deps): update dependency typescript to v4.2.3" ([@9renpoto](https://github.com/9renpoto))
  - [#2751](https://github.com/9renpoto/frontend/pull/2751) chore(deps): update dependency typescript to v4.2.3 ([@renovate[bot]](https://github.com/apps/renovate))
- Other
  - [#2742](https://github.com/9renpoto/frontend/pull/2742) fix(deps): bump pug-code-gen from 2.0.2 to 2.0.3 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2744](https://github.com/9renpoto/frontend/pull/2744) fix(deps): bump linaria from 2.0.2 to 2.1.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2740](https://github.com/9renpoto/frontend/pull/2740) fix(deps): bump @nuxt/content from 1.13.1 to 1.14.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2722](https://github.com/9renpoto/frontend/pull/2722) fix(deps): bump @typescript-eslint/parser from 4.16.0 to 4.16.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2741](https://github.com/9renpoto/frontend/pull/2741) chore(deps): update dependency lerna to v4 ([@renovate[bot]](https://github.com/apps/renovate))
  - [#2694](https://github.com/9renpoto/frontend/pull/2694) chore(deps-dev): bump @nuxt/typescript-build from 1.0.3 to 2.0.6 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2695](https://github.com/9renpoto/frontend/pull/2695) fix(deps): bump eslint-plugin-flowtype from 5.3.0 to 5.3.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2713](https://github.com/9renpoto/frontend/pull/2713) fix(deps): bump @typescript-eslint/parser from 4.15.2 to 4.16.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2714](https://github.com/9renpoto/frontend/pull/2714) fix(deps): bump core-js from 3.9.0 to 3.9.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2687](https://github.com/9renpoto/frontend/pull/2687) fix(deps): bump eslint-plugin-flowtype from 5.2.0 to 5.3.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2688](https://github.com/9renpoto/frontend/pull/2688) fix(deps): bump core-js from 3.8.3 to 3.9.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2689](https://github.com/9renpoto/frontend/pull/2689) fix(deps): bump @typescript-eslint/parser from 4.15.1 to 4.15.2 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2682](https://github.com/9renpoto/frontend/pull/2682) fix(deps): update dependency react-instantsearch-dom to v6.10.0 ([@renovate[bot]](https://github.com/apps/renovate))
  - [#2681](https://github.com/9renpoto/frontend/pull/2681) chore(deps): update dependency @nuxt/types to v2.15.2 ([@renovate[bot]](https://github.com/apps/renovate))
  - [#2659](https://github.com/9renpoto/frontend/pull/2659) fix(deps): bump @headlessui/react from 0.3.0 to 0.3.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2663](https://github.com/9renpoto/frontend/pull/2663) fix(deps): bump @typescript-eslint/parser from 4.15.0 to 4.15.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2656](https://github.com/9renpoto/frontend/pull/2656) Next ([@9renpoto](https://github.com/9renpoto))
  - [#2640](https://github.com/9renpoto/frontend/pull/2640) fix(deps): bump @nuxtjs/axios from 5.13.0 to 5.13.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2646](https://github.com/9renpoto/frontend/pull/2646) fix(deps): bump @nuxt/content from 1.12.0 to 1.13.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2648](https://github.com/9renpoto/frontend/pull/2648) chore(deps-dev): bump typescript from 3.9.7 to 3.9.9 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2637](https://github.com/9renpoto/frontend/pull/2637) fix(deps): bump @typescript-eslint/parser from 4.14.2 to 4.15.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2629](https://github.com/9renpoto/frontend/pull/2629) chore(deps): update dependency vnu-jar to v21 ([@renovate[bot]](https://github.com/apps/renovate))
  - [#2626](https://github.com/9renpoto/frontend/pull/2626) chore(deps-dev): bump @vue/test-utils from 1.1.2 to 1.1.3 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2627](https://github.com/9renpoto/frontend/pull/2627) chore(deps): update dependency ts-loader to v8.0.15 ([@renovate[bot]](https://github.com/apps/renovate))
  - [#2617](https://github.com/9renpoto/frontend/pull/2617) fix(deps): bump gatsby-plugin-google-gtag from 2.7.0 to 2.8.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2621](https://github.com/9renpoto/frontend/pull/2621) fix(deps): bump @typescript-eslint/parser from 4.14.1 to 4.14.2 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2611](https://github.com/9renpoto/frontend/pull/2611) chore(deps): update dependency cypress to v6.4.0 ([@renovate[bot]](https://github.com/apps/renovate))
  - [#2610](https://github.com/9renpoto/frontend/pull/2610) fix(deps): bump @nuxtjs/axios from 5.12.5 to 5.13.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2608](https://github.com/9renpoto/frontend/pull/2608) fix(deps): bump @nuxt/content from 1.11.1 to 1.12.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2609](https://github.com/9renpoto/frontend/pull/2609) chore(deps-dev): bump @prettier/plugin-pug from 1.13.2 to 1.13.3 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2596](https://github.com/9renpoto/frontend/pull/2596) fix(deps): bump @typescript-eslint/parser from 4.14.0 to 4.14.1 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2597](https://github.com/9renpoto/frontend/pull/2597) fix(deps): bump graphql from 15.4.0 to 15.5.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2600](https://github.com/9renpoto/frontend/pull/2600) fix(deps): bump @nuxtjs/pwa from 3.3.4 to 3.3.5 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2583](https://github.com/9renpoto/frontend/pull/2583) fix(deps): bump gatsby-plugin-google-gtag from 2.6.0 to 2.7.0 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
  - [#2581](https://github.com/9renpoto/frontend/pull/2581) Update dependabot.yml ([@9renpoto](https://github.com/9renpoto))
- `eslint-config-typescript`
  - [#2700](https://github.com/9renpoto/frontend/pull/2700) chore(deps-dev): bump typescript from 3.9.9 to 4.2.2 ([@dependabot[bot]](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates))
- `eslint-config-nuxt`, `eslint-config`
  - [#2655](https://github.com/9renpoto/frontend/pull/2655) chore(deps): update dependency eslint to v7.20.0 ([@renovate[bot]](https://github.com/apps/renovate))
- `textlint-config-ja`
  - [#2590](https://github.com/9renpoto/frontend/pull/2590) chore(deps): update dependency textlint to v11.8.1 ([@renovate[bot]](https://github.com/apps/renovate))
  - [#2589](https://github.com/9renpoto/frontend/pull/2589) chore(deps): update dependency textlint to v11.8.0 ([@renovate[bot]](https://github.com/apps/renovate))
- `eslint-config-react`
  - [#2580](https://github.com/9renpoto/frontend/pull/2580) fix: deps ([@9renpoto](https://github.com/9renpoto))

#### Committers: 1

- Keisuke Kan ([@9renpoto](https://github.com/9renpoto))