### PR TITLE
build(deps): Update biomejs to v2.2.3

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,10 +1,8 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "files": {
-    "ignore": []
+    "includes": ["**"]
   },
   "formatter": {
     "indentStyle": "space"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -10,7 +10,7 @@
         "apps/*"
       ],
       "devDependencies": {
-        "@biomejs/biome": "^1.8.2",
+        "@biomejs/biome": "2.2.3",
         "husky": "^9.1.7",
         "lint-staged": "^15.5.2",
         "npm-run-all": "^4.1.5",
@@ -271,11 +271,10 @@
       "peer": true
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.2.3.tgz",
+      "integrity": "sha512-9w0uMTvPrIdvUrxazZ42Ib7t8Y2yoGLKLdNne93RLICmaHw7mcLv4PPb5LvZLJF3141gQHiCColOh/v6VWlWmg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
         "biome": "bin/biome"
@@ -288,20 +287,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.9.4",
-        "@biomejs/cli-darwin-x64": "1.9.4",
-        "@biomejs/cli-linux-arm64": "1.9.4",
-        "@biomejs/cli-linux-arm64-musl": "1.9.4",
-        "@biomejs/cli-linux-x64": "1.9.4",
-        "@biomejs/cli-linux-x64-musl": "1.9.4",
-        "@biomejs/cli-win32-arm64": "1.9.4",
-        "@biomejs/cli-win32-x64": "1.9.4"
+        "@biomejs/cli-darwin-arm64": "2.2.3",
+        "@biomejs/cli-darwin-x64": "2.2.3",
+        "@biomejs/cli-linux-arm64": "2.2.3",
+        "@biomejs/cli-linux-arm64-musl": "2.2.3",
+        "@biomejs/cli-linux-x64": "2.2.3",
+        "@biomejs/cli-linux-x64-musl": "2.2.3",
+        "@biomejs/cli-win32-arm64": "2.2.3",
+        "@biomejs/cli-win32-x64": "2.2.3"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.3.tgz",
+      "integrity": "sha512-OrqQVBpadB5eqzinXN4+Q6honBz+tTlKVCsbEuEpljK8ASSItzIRZUA02mTikl3H/1nO2BMPFiJ0nkEZNy3B1w==",
       "cpu": [
         "arm64"
       ],
@@ -316,9 +315,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.3.tgz",
+      "integrity": "sha512-OCdBpb1TmyfsTgBAM1kPMXyYKTohQ48WpiN9tkt9xvU6gKVKHY4oVwteBebiOqyfyzCNaSiuKIPjmHjUZ2ZNMg==",
       "cpu": [
         "x64"
       ],
@@ -333,9 +332,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.3.tgz",
+      "integrity": "sha512-g/Uta2DqYpECxG+vUmTAmUKlVhnGEcY7DXWgKP8ruLRa8Si1QHsWknPY3B/wCo0KgYiFIOAZ9hjsHfNb9L85+g==",
       "cpu": [
         "arm64"
       ],
@@ -350,9 +349,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.3.tgz",
+      "integrity": "sha512-q3w9jJ6JFPZPeqyvwwPeaiS/6NEszZ+pXKF+IczNo8Xj6fsii45a4gEEicKyKIytalV+s829ACZujQlXAiVLBQ==",
       "cpu": [
         "arm64"
       ],
@@ -367,9 +366,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.3.tgz",
+      "integrity": "sha512-LEtyYL1fJsvw35CxrbQ0gZoxOG3oZsAjzfRdvRBRHxOpQ91Q5doRVjvWW/wepgSdgk5hlaNzfeqpyGmfSD0Eyw==",
       "cpu": [
         "x64"
       ],
@@ -384,9 +383,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.2.3.tgz",
+      "integrity": "sha512-y76Dn4vkP1sMRGPFlNc+OTETBhGPJ90jY3il6jAfur8XWrYBQV3swZ1Jo0R2g+JpOeeoA0cOwM7mJG6svDz79w==",
       "cpu": [
         "x64"
       ],
@@ -401,9 +400,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.3.tgz",
+      "integrity": "sha512-Ms9zFYzjcJK7LV+AOMYnjN3pV3xL8Prxf9aWdDVL74onLn5kcvZ1ZMQswE5XHtnd/r/0bnUd928Rpbs14BzVmA==",
       "cpu": [
         "arm64"
       ],
@@ -418,9 +417,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.2.3.tgz",
+      "integrity": "sha512-gvCpewE7mBwBIpqk1YrUqNR4mCiyJm6UI3YWQQXkedSSEwzRdodRpaKhbdbHw1/hmTWOVXQ+Eih5Qctf4TCVOQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run test -ws --if-present"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.8.2",
+    "@biomejs/biome": "2.2.3",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.2",
     "npm-run-all": "^4.1.5",
@@ -25,14 +25,30 @@
     ]
   },
   "lint-staged": {
-    "*.pug": ["prettier --write --plugin=@prettier/plugin-pug"],
-    "*.{ts,tsx,json}": ["biome check --apply"],
-    "*.md": ["textlint"],
-    "*.{ts,tsx}": ["eslint --fix", "biome check --apply"],
-    "*.tsx": ["stylelint --fix"]
+    "*.pug": [
+      "prettier --write --plugin=@prettier/plugin-pug"
+    ],
+    "*.{ts,tsx,json}": [
+      "biome check --write"
+    ],
+    "*.md": [
+      "textlint"
+    ],
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "biome check --write"
+    ],
+    "*.tsx": [
+      "stylelint --fix"
+    ]
   },
   "stylelint": {
-    "extends": ["@9renpoto/stylelint-config"]
+    "extends": [
+      "@9renpoto/stylelint-config"
+    ]
   },
-  "workspaces": ["packages/*", "apps/*"]
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ]
 }

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -13,7 +13,10 @@
     "url": "https://github.com/9renpoto/frontend/issues"
   },
   "main": "index.js",
-  "keywords": ["eslint", "react"],
+  "keywords": [
+    "eslint",
+    "react"
+  ],
   "peerDependencies": {
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -13,7 +13,10 @@
     "url": "https://github.com/9renpoto/frontend/issues"
   },
   "main": "index.js",
-  "keywords": ["eslint", "TypeScript"],
+  "keywords": [
+    "eslint",
+    "TypeScript"
+  ],
   "peerDependencies": {
     "@9renpoto/eslint-config": "^7.7.0",
     "@typescript-eslint/parser": "^6.0.0"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,7 +13,10 @@
     "url": "https://github.com/9renpoto/frontend/issues"
   },
   "main": "index.js",
-  "keywords": ["config", "eslint"],
+  "keywords": [
+    "config",
+    "eslint"
+  ],
   "peerDependencies": {
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -13,7 +13,9 @@
     "url": "https://github.com/9renpoto/frontend/issues"
   },
   "main": "index.js",
-  "keywords": ["stylelint-config"],
+  "keywords": [
+    "stylelint-config"
+  ],
   "peerDependencies": {
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-recess-order": "^4.0.0"

--- a/packages/textlint-config-ja/package.json
+++ b/packages/textlint-config-ja/package.json
@@ -8,7 +8,10 @@
   "scripts": {
     "lint": "textlint README.md --cache"
   },
-  "keywords": ["ja", "textlint"],
+  "keywords": [
+    "ja",
+    "textlint"
+  ],
   "peerDependencies": {
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-incremental-headers": "^0.2.0",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -4,8 +4,16 @@
   "description": "Shared TypeScript config for my projects",
   "license": "MIT",
   "main": "tsconfig.json",
-  "files": ["tsconfig.json"],
-  "keywords": ["tsconfig", "typescript", "ts", "config", "configuration"],
+  "files": [
+    "tsconfig.json"
+  ],
+  "keywords": [
+    "tsconfig",
+    "typescript",
+    "ts",
+    "config",
+    "configuration"
+  ],
   "peerDependencies": {
     "typescript": "^5.0.0"
   }


### PR DESCRIPTION
This commit updates `@biomejs/biome` from `^1.8.2` to `2.2.3`.

The following changes were made to accommodate the new version:

- The `biome.json` configuration file was migrated to the new format using `npx biome migrate --write`.
- The `lint-staged` command in `package.json` was updated from `biome check --apply` to `biome check --write`, as the `--apply` flag is deprecated.
- All `package.json` files in the repository have been reformatted. This was necessary because the new version of Biome enforces stricter formatting rules for JSON files, and running `biome check --write .` was required to make the pre-commit checks pass.